### PR TITLE
changes to avhrr_gacfunction and read_tle_decimal

### DIFF
--- a/pyorbital/geoloc_instrument_definitions.py
+++ b/pyorbital/geoloc_instrument_definitions.py
@@ -79,7 +79,7 @@ def avhrr_gac(scan_times, scan_points,
         offset = np.array([(t - scan_times[0]).seconds +
                            (t - scan_times[0]).microseconds / 1000000.0 for t in scan_times])
     except TypeError:
-        offset = np.arange(scans_nb) * frequency
+        offset = np.arange(scan_times) * frequency
     scans_nb = len(offset)
     # build the avhrr instrument (scan angles)
     avhrr_inst = np.vstack(((scan_points / 1023.5 - 1)

--- a/pyorbital/tlefile.py
+++ b/pyorbital/tlefile.py
@@ -128,7 +128,7 @@ class Tle(object):
     def _read_tle(self):
 
         def _read_tle_decimal(rep):
-            if rep[0] in ["-", " "]:
+            if rep[0] in ["-", " ", "+"]:
                 digits = rep[1:-2].strip()
                 val = rep[0] + "." + digits + "e" + rep[-2:]
             else:


### PR DESCRIPTION
# TLE files have also '+', which can be used as delimiter, so added that..

# 'scans_nb' is defined later in geoloc_instrument_definitions.py
